### PR TITLE
feat: implement cms backend and storage

### DIFF
--- a/src/apps/api/prisma/schema.prisma
+++ b/src/apps/api/prisma/schema.prisma
@@ -28,6 +28,9 @@ model User {
   forms         Form[]
   secretarias   Secretaria[]
   media_files   MediaFile[]
+  posts         Post[]
+  tourismPoints TourismPoint[]
+  permissions   UserPermission[]
 
   @@map("users")
 }
@@ -50,6 +53,82 @@ model Page {
   author    User   @relation(fields: [author_id], references: [id])
 
   @@map("pages")
+}
+
+model Post {
+  id              String      @id @default(cuid())
+  title           String
+  slug            String      @unique
+  content         String      @db.Text
+  excerpt         String?     @db.Text
+  featured_image  String?
+  status          PostStatus  @default(DRAFT)
+  publish_at      DateTime?
+  seo_title       String?
+  seo_description String?     @db.Text
+  views           Int         @default(0)
+  created_at      DateTime    @default(now())
+  updated_at      DateTime    @updatedAt
+
+  // Relations
+  author_id String
+  author    User           @relation(fields: [author_id], references: [id])
+  categories PostCategory[]
+  tags       PostTag[]
+
+  @@map("posts")
+}
+
+model PostCategory {
+  post_id     String
+  category_id String
+
+  post     Post     @relation(fields: [post_id], references: [id], onDelete: Cascade)
+  category Category @relation(fields: [category_id], references: [id], onDelete: Cascade)
+
+  @@id([post_id, category_id])
+  @@map("post_categories")
+}
+
+model PostTag {
+  post_id String
+  tag_id  String
+
+  post Post @relation(fields: [post_id], references: [id], onDelete: Cascade)
+  tag  Tag  @relation(fields: [tag_id], references: [id], onDelete: Cascade)
+
+  @@id([post_id, tag_id])
+  @@map("post_tags")
+}
+
+model Category {
+  id          String        @id @default(cuid())
+  name        String
+  slug        String        @unique
+  description String?       @db.Text
+  type        CategoryType
+  created_at  DateTime      @default(now())
+  updated_at  DateTime      @updatedAt
+
+  // Relations
+  posts PostCategory[]
+
+  @@map("categories")
+}
+
+model Tag {
+  id          String   @id @default(cuid())
+  name        String
+  slug        String   @unique
+  description String?  @db.Text
+  type        TagType
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  // Relations
+  posts PostTag[]
+
+  @@map("tags")
 }
 
 model Slide {
@@ -197,6 +276,28 @@ model Secretaria {
   @@map("secretarias")
 }
 
+model TourismPoint {
+  id           String   @id @default(cuid())
+  name         String
+  slug         String   @unique
+  description  String   @db.Text
+  address      String?
+  latitude     Float?
+  longitude    Float?
+  image        String?
+  gallery      String[] @default([])
+  contact_info String?  @db.Text
+  active       Boolean  @default(true)
+  created_at   DateTime @default(now())
+  updated_at   DateTime @updatedAt
+
+  // Relations
+  author_id String
+  author    User @relation(fields: [author_id], references: [id])
+
+  @@map("tourism_points")
+}
+
 model MediaFile {
   id            String   @id @default(cuid())
   filename      String
@@ -227,11 +328,42 @@ model Setting {
   @@map("settings")
 }
 
+model Permission {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?  @db.Text
+  scopes      String[] @default([])
+  created_at  DateTime @default(now())
+  updated_at  DateTime @updatedAt
+
+  users UserPermission[]
+
+  @@map("permissions")
+}
+
+model UserPermission {
+  user_id       String
+  permission_id String
+  granted_at    DateTime @default(now())
+
+  user       User       @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  permission Permission @relation(fields: [permission_id], references: [id], onDelete: Cascade)
+
+  @@id([user_id, permission_id])
+  @@map("user_permissions")
+}
+
 // Enums
 enum UserRole {
   ADMIN
   EDITOR
   VIEWER
+}
+
+enum PostStatus {
+  DRAFT
+  PUBLISHED
+  ARCHIVED
 }
 
 enum PageStatus {
@@ -244,4 +376,22 @@ enum EventStatus {
   DRAFT
   PUBLISHED
   CANCELLED
+}
+
+enum CategoryType {
+  POST
+  SERVICE
+  EVENT
+  PAGE
+  TOURISM
+  GALLERY
+}
+
+enum TagType {
+  POST
+  SERVICE
+  EVENT
+  PAGE
+  TOURISM
+  GALLERY
 }

--- a/src/apps/api/src/app.module.ts
+++ b/src/apps/api/src/app.module.ts
@@ -9,6 +9,14 @@ import { MediaModule } from './media/media.module';
 import { FormsModule } from './forms/forms.module';
 import { SecretariasModule } from './secretarias/secretarias.module';
 import { ServicesModule } from './services/services.module';
+import { EventsModule } from './events/events.module';
+import { SlidesModule } from './slides/slides.module';
+import { GalleriesModule } from './galleries/galleries.module';
+import { CategoriesModule } from './categories/categories.module';
+import { TagsModule } from './tags/tags.module';
+import { TourismModule } from './tourism/tourism.module';
+import { PermissionsModule } from './permissions/permissions.module';
+import { SettingsModule } from './settings/settings.module';
 
 @Module({
   imports: [
@@ -25,6 +33,14 @@ import { ServicesModule } from './services/services.module';
     FormsModule,
     SecretariasModule,
     ServicesModule,
+    EventsModule,
+    SlidesModule,
+    GalleriesModule,
+    CategoriesModule,
+    TagsModule,
+    TourismModule,
+    PermissionsModule,
+    SettingsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/apps/api/src/auth/auth.controller.ts
+++ b/src/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Post, Body, UseGuards } from '@nestjs/common';
+import { AuthService } from './auth.service';
+import { LoginDto, RegisterDto } from './dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @Post('login')
+  async login(@Body() loginDto: LoginDto) {
+    return this.authService.login(loginDto);
+  }
+
+  @Post('register')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  async register(@Body() registerDto: RegisterDto) {
+    return this.authService.register(registerDto);
+  }
+
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  async me(@CurrentUser() user: any) {
+    return user;
+  }
+}

--- a/src/apps/api/src/auth/dto/index.ts
+++ b/src/apps/api/src/auth/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './login.dto';
+export * from './register.dto';

--- a/src/apps/api/src/auth/dto/login.dto.ts
+++ b/src/apps/api/src/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  password: string;
+}

--- a/src/apps/api/src/auth/dto/register.dto.ts
+++ b/src/apps/api/src/auth/dto/register.dto.ts
@@ -1,0 +1,19 @@
+import { IsEmail, IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { UserRole } from '@prisma/client';
+
+export class RegisterDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(3)
+  name: string;
+
+  @IsString()
+  @MinLength(8)
+  password: string;
+
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole = UserRole.EDITOR;
+}

--- a/src/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/src/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor(configService: ConfigService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_SECRET') || 'super-secret-jwt-key',
+    });
+  }
+
+  async validate(payload: any) {
+    return { id: payload.sub, email: payload.email, role: payload.role };
+  }
+}

--- a/src/apps/api/src/auth/strategies/local.strategy.ts
+++ b/src/apps/api/src/auth/strategies/local.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-local';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+  constructor(private authService: AuthService) {
+    super({ usernameField: 'email' });
+  }
+
+  async validate(email: string, password: string): Promise<any> {
+    const user = await this.authService.validateUser(email, password);
+    if (!user) {
+      throw new UnauthorizedException('Credenciais inválidas');
+    }
+    return user;
+  }
+}

--- a/src/apps/api/src/categories/categories.controller.ts
+++ b/src/apps/api/src/categories/categories.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryQueryDto } from './dto/category-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('categories')
+@Controller('categories')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: CategoryQueryDto) {
+    return this.categoriesService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.categoriesService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateCategoryDto) {
+    return this.categoriesService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateCategoryDto) {
+    return this.categoriesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.categoriesService.delete(id);
+  }
+}

--- a/src/apps/api/src/categories/categories.module.ts
+++ b/src/apps/api/src/categories/categories.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { CategoriesService } from './categories.service';
+import { CategoriesController } from './categories.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [CategoriesService],
+  controllers: [CategoriesController],
+})
+export class CategoriesModule {}

--- a/src/apps/api/src/categories/categories.service.ts
+++ b/src/apps/api/src/categories/categories.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { Category, CategoryType, Prisma } from '@prisma/client';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    type?: CategoryType;
+  }): Promise<{ data: Category[]; total: number }> {
+    const { skip = 0, take = 25, search, type } = params;
+
+    const where: Prisma.CategoryWhereInput = {
+      ...(type ? { type } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { slug: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.category.count({ where }),
+      this.prisma.category.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const category = await this.prisma.category.findUnique({ where: { id } });
+    if (!category) {
+      throw new NotFoundException('Categoria não encontrada');
+    }
+    return category;
+  }
+
+  async create(dto: CreateCategoryDto) {
+    return this.prisma.category.create({ data: dto });
+  }
+
+  async update(id: string, dto: UpdateCategoryDto) {
+    await this.ensureExists(id);
+    return this.prisma.category.update({ where: { id }, data: dto });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.category.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.category.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Categoria não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/categories/dto/category-query.dto.ts
+++ b/src/apps/api/src/categories/dto/category-query.dto.ts
@@ -1,0 +1,9 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { CategoryType } from '@prisma/client';
+
+export class CategoryQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsEnum(CategoryType)
+  type?: CategoryType;
+}

--- a/src/apps/api/src/categories/dto/create-category.dto.ts
+++ b/src/apps/api/src/categories/dto/create-category.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { CategoryType } from '@prisma/client';
+
+export class CreateCategoryDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  slug: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsEnum(CategoryType)
+  type: CategoryType;
+}

--- a/src/apps/api/src/categories/dto/update-category.dto.ts
+++ b/src/apps/api/src/categories/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/apps/api/src/common/decorators/current-user.decorator.ts
+++ b/src/apps/api/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/apps/api/src/common/decorators/roles.decorator.ts
+++ b/src/apps/api/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/apps/api/src/common/dto/pagination-query.dto.ts
+++ b/src/apps/api/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,21 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  skip?: number = 0;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  take?: number = 25;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/src/apps/api/src/common/guards/jwt-auth.guard.ts
+++ b/src/apps/api/src/common/guards/jwt-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/apps/api/src/common/guards/roles.guard.ts
+++ b/src/apps/api/src/common/guards/roles.guard.ts
@@ -1,0 +1,23 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '@prisma/client';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const { user } = context.switchToHttp().getRequest();
+    return requiredRoles.includes(user?.role);
+  }
+}

--- a/src/apps/api/src/events/dto/create-event.dto.ts
+++ b/src/apps/api/src/events/dto/create-event.dto.ts
@@ -1,0 +1,39 @@
+import {
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+import { EventStatus } from '@prisma/client';
+
+export class CreateEventDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsDateString()
+  start_date: string;
+
+  @IsOptional()
+  @IsDateString()
+  end_date?: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsOptional()
+  @IsUrl()
+  image?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @IsOptional()
+  @IsEnum(EventStatus)
+  status?: EventStatus;
+}

--- a/src/apps/api/src/events/dto/event-query.dto.ts
+++ b/src/apps/api/src/events/dto/event-query.dto.ts
@@ -1,0 +1,9 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { EventStatus } from '@prisma/client';
+
+export class EventQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsEnum(EventStatus)
+  status?: EventStatus;
+}

--- a/src/apps/api/src/events/dto/update-event.dto.ts
+++ b/src/apps/api/src/events/dto/update-event.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateEventDto } from './create-event.dto';
+
+export class UpdateEventDto extends PartialType(CreateEventDto) {}

--- a/src/apps/api/src/events/events.controller.ts
+++ b/src/apps/api/src/events/events.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { EventsService } from './events.service';
+import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { EventQueryDto } from './dto/event-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('events')
+@Controller('events')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class EventsController {
+  constructor(private readonly eventsService: EventsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: EventQueryDto) {
+    return this.eventsService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.eventsService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateEventDto, @CurrentUser() user: any) {
+    return this.eventsService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateEventDto) {
+    return this.eventsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.eventsService.delete(id);
+  }
+}

--- a/src/apps/api/src/events/events.module.ts
+++ b/src/apps/api/src/events/events.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { EventsService } from './events.service';
+import { EventsController } from './events.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [EventsController],
+  providers: [EventsService],
+})
+export class EventsModule {}

--- a/src/apps/api/src/events/events.service.ts
+++ b/src/apps/api/src/events/events.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { EventStatus, Prisma } from '@prisma/client';
+
+const eventInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+};
+
+type EventWithAuthor = Prisma.EventGetPayload<{ include: typeof eventInclude }>;
+
+@Injectable()
+export class EventsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    status?: EventStatus;
+  }): Promise<{ data: EventWithAuthor[]; total: number }> {
+    const { skip = 0, take = 25, search, status } = params;
+
+    const where: Prisma.EventWhereInput = {
+      ...(status ? { status } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.event.count({ where }),
+      this.prisma.event.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { start_date: 'desc' },
+        include: eventInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<EventWithAuthor> {
+    const event = await this.prisma.event.findUnique({
+      where: { id },
+      include: eventInclude,
+    });
+
+    if (!event) {
+      throw new NotFoundException('Evento não encontrado');
+    }
+
+    return event;
+  }
+
+  async create(dto: CreateEventDto, authorId: string): Promise<EventWithAuthor> {
+    return this.prisma.event.create({
+      data: {
+        ...dto,
+        author: { connect: { id: authorId } },
+      },
+      include: eventInclude,
+    });
+  }
+
+  async update(id: string, dto: UpdateEventDto): Promise<EventWithAuthor> {
+    await this.ensureExists(id);
+    return this.prisma.event.update({
+      where: { id },
+      data: dto,
+      include: eventInclude,
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.event.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.event.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Evento não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/forms/dto/create-form-response.dto.ts
+++ b/src/apps/api/src/forms/dto/create-form-response.dto.ts
@@ -1,0 +1,14 @@
+import { IsIP, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class CreateFormResponseDto {
+  @IsObject()
+  data: Record<string, any>;
+
+  @IsOptional()
+  @IsIP()
+  ip_address?: string;
+
+  @IsOptional()
+  @IsString()
+  user_agent?: string;
+}

--- a/src/apps/api/src/forms/dto/create-form.dto.ts
+++ b/src/apps/api/src/forms/dto/create-form.dto.ts
@@ -1,0 +1,25 @@
+import { IsArray, IsBoolean, IsObject, IsOptional, IsString } from 'class-validator';
+
+export class CreateFormDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  slug: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  fields?: any[];
+
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, any>;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/forms/dto/update-form.dto.ts
+++ b/src/apps/api/src/forms/dto/update-form.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateFormDto } from './create-form.dto';
+
+export class UpdateFormDto extends PartialType(CreateFormDto) {}

--- a/src/apps/api/src/forms/form-responses.controller.ts
+++ b/src/apps/api/src/forms/form-responses.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { FormsService } from './forms.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { CreateFormResponseDto } from './dto/create-form-response.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('forms')
+@Controller('forms/:formId/responses')
+export class FormResponsesController {
+  constructor(private readonly formsService: FormsService) {}
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  list(@Param('formId') formId: string, @Query() query: PaginationQueryDto) {
+    return this.formsService.listResponses(formId, query);
+  }
+
+  @Post()
+  submit(
+    @Param('formId') formId: string,
+    @Body() dto: CreateFormResponseDto,
+  ) {
+    return this.formsService.submitResponse(formId, dto);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  remove(@Param('formId') formId: string, @Param('id') id: string) {
+    return this.formsService.deleteResponse(formId, id);
+  }
+}

--- a/src/apps/api/src/forms/forms.controller.ts
+++ b/src/apps/api/src/forms/forms.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { FormsService } from './forms.service';
+import { CreateFormDto } from './dto/create-form.dto';
+import { UpdateFormDto } from './dto/update-form.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('forms')
+@Controller('forms')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class FormsController {
+  constructor(private readonly formsService: FormsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: PaginationQueryDto) {
+    return this.formsService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.formsService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateFormDto, @CurrentUser() user: any) {
+    return this.formsService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateFormDto) {
+    return this.formsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.formsService.delete(id);
+  }
+}

--- a/src/apps/api/src/forms/forms.module.ts
+++ b/src/apps/api/src/forms/forms.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { FormsService } from './forms.service';
+import { FormsController } from './forms.controller';
+import { FormResponsesController } from './form-responses.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [FormsController, FormResponsesController],
+  providers: [FormsService],
+})
+export class FormsModule {}

--- a/src/apps/api/src/forms/forms.service.ts
+++ b/src/apps/api/src/forms/forms.service.ts
@@ -1,0 +1,137 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateFormDto } from './dto/create-form.dto';
+import { UpdateFormDto } from './dto/update-form.dto';
+import { Prisma } from '@prisma/client';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { CreateFormResponseDto } from './dto/create-form-response.dto';
+
+@Injectable()
+export class FormsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: PaginationQueryDto) {
+    const { skip = 0, take = 25, search } = params;
+
+    const where: Prisma.FormWhereInput = search
+      ? {
+          OR: [
+            { title: { contains: search, mode: 'insensitive' } },
+            { description: { contains: search, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.form.count({ where }),
+      this.prisma.form.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: {
+          author: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const form = await this.prisma.form.findUnique({
+      where: { id },
+      include: {
+        author: {
+          select: { id: true, name: true, email: true },
+        },
+      },
+    });
+
+    if (!form) {
+      throw new NotFoundException('Formulário não encontrado');
+    }
+
+    return form;
+  }
+
+  async create(dto: CreateFormDto, authorId: string) {
+    return this.prisma.form.create({
+      data: {
+        ...dto,
+        author: { connect: { id: authorId } },
+      },
+      include: {
+        author: {
+          select: { id: true, name: true, email: true },
+        },
+      },
+    });
+  }
+
+  async update(id: string, dto: UpdateFormDto) {
+    await this.ensureExists(id);
+    return this.prisma.form.update({
+      where: { id },
+      data: dto,
+      include: {
+        author: {
+          select: { id: true, name: true, email: true },
+        },
+      },
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.form.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  async listResponses(formId: string, params: PaginationQueryDto) {
+    await this.ensureExists(formId);
+    const { skip = 0, take = 25 } = params;
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.formSubmission.count({ where: { form_id: formId } }),
+      this.prisma.formSubmission.findMany({
+        where: { form_id: formId },
+        skip,
+        take,
+        orderBy: { submitted_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async submitResponse(formId: string, dto: CreateFormResponseDto) {
+    await this.ensureExists(formId);
+    return this.prisma.formSubmission.create({
+      data: {
+        form: { connect: { id: formId } },
+        data: dto.data,
+        ip_address: dto.ip_address,
+        user_agent: dto.user_agent,
+      },
+    });
+  }
+
+  async deleteResponse(formId: string, id: string) {
+    const submission = await this.prisma.formSubmission.findUnique({ where: { id } });
+    if (!submission || submission.form_id !== formId) {
+      throw new NotFoundException('Resposta não encontrada');
+    }
+    await this.prisma.formSubmission.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.form.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Formulário não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/galleries/dto/create-gallery.dto.ts
+++ b/src/apps/api/src/galleries/dto/create-gallery.dto.ts
@@ -1,0 +1,25 @@
+import { Type } from 'class-transformer';
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+import { GalleryImageDto } from './gallery-image.dto';
+
+export class CreateGalleryDto {
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+
+  @IsOptional()
+  @IsArray()
+  @Type(() => GalleryImageDto)
+  images?: GalleryImageDto[];
+}

--- a/src/apps/api/src/galleries/dto/gallery-image.dto.ts
+++ b/src/apps/api/src/galleries/dto/gallery-image.dto.ts
@@ -1,0 +1,19 @@
+import { IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GalleryImageDto {
+  @IsUrl()
+  url: string;
+
+  @IsString()
+  alt: string;
+
+  @IsOptional()
+  @IsString()
+  caption?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  order?: number;
+}

--- a/src/apps/api/src/galleries/dto/gallery-query.dto.ts
+++ b/src/apps/api/src/galleries/dto/gallery-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsBooleanString, IsOptional } from 'class-validator';
+
+export class GalleryQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsBooleanString()
+  active?: string;
+}

--- a/src/apps/api/src/galleries/dto/update-gallery.dto.ts
+++ b/src/apps/api/src/galleries/dto/update-gallery.dto.ts
@@ -1,0 +1,12 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateGalleryDto } from './create-gallery.dto';
+import { IsOptional, IsArray } from 'class-validator';
+import { GalleryImageDto } from './gallery-image.dto';
+import { Type } from 'class-transformer';
+
+export class UpdateGalleryDto extends PartialType(CreateGalleryDto) {
+  @IsOptional()
+  @IsArray()
+  @Type(() => GalleryImageDto)
+  images?: GalleryImageDto[];
+}

--- a/src/apps/api/src/galleries/galleries.controller.ts
+++ b/src/apps/api/src/galleries/galleries.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { GalleriesService } from './galleries.service';
+import { CreateGalleryDto } from './dto/create-gallery.dto';
+import { UpdateGalleryDto } from './dto/update-gallery.dto';
+import { GalleryQueryDto } from './dto/gallery-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('galleries')
+@Controller('galleries')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class GalleriesController {
+  constructor(private readonly galleriesService: GalleriesService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: GalleryQueryDto) {
+    const { active, ...rest } = query;
+    return this.galleriesService.findAll({
+      ...rest,
+      active: active !== undefined ? active === 'true' : undefined,
+    });
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.galleriesService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateGalleryDto, @CurrentUser() user: any) {
+    return this.galleriesService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateGalleryDto) {
+    return this.galleriesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.galleriesService.delete(id);
+  }
+}

--- a/src/apps/api/src/galleries/galleries.module.ts
+++ b/src/apps/api/src/galleries/galleries.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { GalleriesService } from './galleries.service';
+import { GalleriesController } from './galleries.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [GalleriesController],
+  providers: [GalleriesService],
+})
+export class GalleriesModule {}

--- a/src/apps/api/src/galleries/galleries.service.ts
+++ b/src/apps/api/src/galleries/galleries.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateGalleryDto } from './dto/create-gallery.dto';
+import { UpdateGalleryDto } from './dto/update-gallery.dto';
+import { Prisma } from '@prisma/client';
+
+const galleryInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  images: true,
+};
+
+type GalleryWithRelations = Prisma.GalleryGetPayload<{ include: typeof galleryInclude }>;
+
+@Injectable()
+export class GalleriesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    active?: boolean;
+  }): Promise<{ data: GalleryWithRelations[]; total: number }> {
+    const { skip = 0, take = 25, search, active } = params;
+
+    const where: Prisma.GalleryWhereInput = {
+      ...(active !== undefined ? { active } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.gallery.count({ where }),
+      this.prisma.gallery.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: galleryInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<GalleryWithRelations> {
+    const gallery = await this.prisma.gallery.findUnique({
+      where: { id },
+      include: galleryInclude,
+    });
+
+    if (!gallery) {
+      throw new NotFoundException('Galeria não encontrada');
+    }
+
+    return gallery;
+  }
+
+  async create(dto: CreateGalleryDto, authorId: string): Promise<GalleryWithRelations> {
+    const { images = [], ...rest } = dto;
+    return this.prisma.gallery.create({
+      data: {
+        ...rest,
+        author: { connect: { id: authorId } },
+        images: {
+          create: images.map((image, index) => ({
+            url: image.url,
+            alt: image.alt,
+            caption: image.caption,
+            order: image.order ?? index,
+          })),
+        },
+      },
+      include: galleryInclude,
+    });
+  }
+
+  async update(id: string, dto: UpdateGalleryDto): Promise<GalleryWithRelations> {
+    const { images, ...rest } = dto;
+    await this.ensureExists(id);
+
+    if (images) {
+      await this.prisma.$transaction([
+        this.prisma.galleryImage.deleteMany({ where: { gallery_id: id } }),
+        this.prisma.galleryImage.createMany({
+          data: images.map((image, index) => ({
+            gallery_id: id,
+            url: image.url,
+            alt: image.alt,
+            caption: image.caption,
+            order: image.order ?? index,
+          })),
+        }),
+      ]);
+    }
+
+    await this.prisma.gallery.update({
+      where: { id },
+      data: rest,
+    });
+
+    return this.findById(id);
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.gallery.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.gallery.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Galeria não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/main.ts
+++ b/src/apps/api/src/main.ts
@@ -40,6 +40,14 @@ async function bootstrap() {
     .addTag('forms', 'Formulários dinâmicos')
     .addTag('secretarias', 'Secretarias municipais')
     .addTag('services', 'Serviços públicos')
+    .addTag('events', 'Eventos e agenda pública')
+    .addTag('slides', 'Banners e destaques do portal')
+    .addTag('galleries', 'Galerias públicas de mídia')
+    .addTag('categories', 'Categorias de conteúdo')
+    .addTag('tags', 'Etiquetas para classificação')
+    .addTag('tourism-points', 'Pontos turísticos de Timon')
+    .addTag('permissions', 'Controle de permissões granulares')
+    .addTag('settings', 'Configurações gerais, SEO e aparência')
     .build();
 
   const document = SwaggerModule.createDocument(app, config);

--- a/src/apps/api/src/media/dto/media-query.dto.ts
+++ b/src/apps/api/src/media/dto/media-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsOptional, IsString } from 'class-validator';
+
+export class MediaQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsString()
+  folder?: string;
+}

--- a/src/apps/api/src/media/dto/update-media.dto.ts
+++ b/src/apps/api/src/media/dto/update-media.dto.ts
@@ -1,0 +1,15 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateMediaDto {
+  @IsOptional()
+  @IsString()
+  alt?: string;
+
+  @IsOptional()
+  @IsString()
+  caption?: string;
+
+  @IsOptional()
+  @IsString()
+  folder?: string;
+}

--- a/src/apps/api/src/media/media.controller.ts
+++ b/src/apps/api/src/media/media.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { MediaService } from './media.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { MediaQueryDto } from './dto/media-query.dto';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { UpdateMediaDto } from './dto/update-media.dto';
+import { BadRequestException } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('media')
+@Controller('media')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class MediaController {
+  constructor(private readonly mediaService: MediaService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: MediaQueryDto) {
+    return this.mediaService.findAll(query);
+  }
+
+  @Post('upload')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  @UseInterceptors(
+    FileInterceptor('file', {
+      storage: memoryStorage(),
+      limits: { fileSize: 1024 * 1024 * 25 },
+    }),
+  )
+  upload(
+    @UploadedFile() file: Express.Multer.File,
+    @CurrentUser() user: any,
+    @Body('folder') folder?: string,
+  ) {
+    if (!file) {
+      throw new BadRequestException('Arquivo é obrigatório');
+    }
+    return this.mediaService.upload(file, user.id, folder);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateMediaDto) {
+    return this.mediaService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.mediaService.delete(id);
+  }
+}

--- a/src/apps/api/src/media/media.module.ts
+++ b/src/apps/api/src/media/media.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { MediaService } from './media.service';
+import { MediaController } from './media.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+import { MinioService } from './storage/minio.service';
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [PrismaModule, ConfigModule],
+  controllers: [MediaController],
+  providers: [MediaService, MinioService],
+})
+export class MediaModule {}

--- a/src/apps/api/src/media/media.service.ts
+++ b/src/apps/api/src/media/media.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { MinioService } from './storage/minio.service';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { UpdateMediaDto } from './dto/update-media.dto';
+
+@Injectable()
+export class MediaService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly minioService: MinioService,
+  ) {}
+
+  async findAll(params: PaginationQueryDto & { folder?: string }) {
+    const { skip = 0, take = 25, search, folder } = params;
+
+    const where = {
+      ...(search
+        ? {
+            OR: [
+              { original_name: { contains: search, mode: 'insensitive' } },
+              { filename: { contains: search, mode: 'insensitive' } },
+              { alt: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+      ...(folder ? { folder } : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.mediaFile.count({ where }),
+      this.prisma.mediaFile.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: {
+          uploader: {
+            select: { id: true, name: true, email: true },
+          },
+        },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async upload(file: Express.Multer.File, userId: string, folder?: string) {
+    const { key, url } = await this.minioService.upload(file, folder);
+
+    return this.prisma.mediaFile.create({
+      data: {
+        filename: key,
+        original_name: file.originalname,
+        mimetype: file.mimetype,
+        size: file.size,
+        url,
+        folder,
+        uploaded_by: userId,
+      },
+      include: {
+        uploader: {
+          select: { id: true, name: true, email: true },
+        },
+      },
+    });
+  }
+
+  async update(id: string, dto: UpdateMediaDto) {
+    await this.ensureExists(id);
+    return this.prisma.mediaFile.update({
+      where: { id },
+      data: dto,
+      include: {
+        uploader: {
+          select: { id: true, name: true, email: true },
+        },
+      },
+    });
+  }
+
+  async delete(id: string) {
+    const media = await this.prisma.mediaFile.findUnique({ where: { id } });
+    if (!media) {
+      throw new NotFoundException('Arquivo de mídia não encontrado');
+    }
+
+    await this.minioService.remove(media.filename);
+    await this.prisma.mediaFile.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.mediaFile.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Arquivo de mídia não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/media/storage/minio.service.ts
+++ b/src/apps/api/src/media/storage/minio.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { S3 } from 'aws-sdk';
+import { v4 as uuid } from 'uuid';
+
+@Injectable()
+export class MinioService {
+  private readonly s3: S3;
+  private readonly bucket: string;
+  private readonly logger = new Logger(MinioService.name);
+
+  constructor(private readonly configService: ConfigService) {
+    const endpoint = this.configService.get<string>('MINIO_ENDPOINT', 'localhost');
+    const port = Number(this.configService.get<number>('MINIO_PORT', 9000));
+    const accessKeyId = this.configService.get<string>('MINIO_ACCESS_KEY', 'minioadmin');
+    const secretAccessKey = this.configService.get<string>('MINIO_SECRET_KEY', 'minioadmin');
+    const useSSL = this.configService.get<string>('MINIO_USE_SSL', 'false') === 'true';
+    this.bucket = this.configService.get<string>('MINIO_BUCKET', 'timon-cms');
+
+    this.s3 = new S3({
+      endpoint: `${useSSL ? 'https' : 'http'}://${endpoint}:${port}`,
+      accessKeyId,
+      secretAccessKey,
+      s3ForcePathStyle: true,
+      signatureVersion: 'v4',
+      sslEnabled: useSSL,
+    });
+  }
+
+  async ensureBucketExists() {
+    try {
+      const buckets = await this.s3.listBuckets().promise();
+      const exists = buckets.Buckets?.some((bucket) => bucket.Name === this.bucket);
+      if (!exists) {
+        await this.s3.createBucket({ Bucket: this.bucket }).promise();
+        this.logger.log(`Bucket ${this.bucket} criado no MinIO`);
+      }
+    } catch (error) {
+      this.logger.error('Erro ao verificar bucket no MinIO', error as Error);
+      throw new InternalServerErrorException('Falha na configuração do armazenamento');
+    }
+  }
+
+  async upload(file: Express.Multer.File, folder?: string) {
+    await this.ensureBucketExists();
+    const key = `${folder ? `${folder}/` : ''}${uuid()}-${file.originalname}`;
+
+    try {
+      const result = await this.s3
+        .upload({
+          Bucket: this.bucket,
+          Key: key,
+          Body: file.buffer,
+          ContentType: file.mimetype,
+          ACL: 'public-read',
+        })
+        .promise();
+
+      return {
+        key,
+        url: result.Location,
+      };
+    } catch (error) {
+      this.logger.error('Erro ao enviar arquivo para o MinIO', error as Error);
+      throw new InternalServerErrorException('Não foi possível fazer upload do arquivo');
+    }
+  }
+
+  async remove(key: string) {
+    await this.ensureBucketExists();
+    try {
+      await this.s3.deleteObject({ Bucket: this.bucket, Key: key }).promise();
+    } catch (error) {
+      this.logger.error('Erro ao remover arquivo do MinIO', error as Error);
+      throw new InternalServerErrorException('Não foi possível remover o arquivo');
+    }
+  }
+}

--- a/src/apps/api/src/pages/dto/create-page.dto.ts
+++ b/src/apps/api/src/pages/dto/create-page.dto.ts
@@ -1,0 +1,34 @@
+import { IsEnum, IsOptional, IsString, IsUrl, MaxLength } from 'class-validator';
+import { PageStatus } from '@prisma/client';
+
+export class CreatePageDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  slug: string;
+
+  @IsString()
+  content: string;
+
+  @IsOptional()
+  @IsString()
+  excerpt?: string;
+
+  @IsOptional()
+  @IsUrl()
+  featured_image?: string;
+
+  @IsOptional()
+  @IsEnum(PageStatus)
+  status?: PageStatus;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  seo_title?: string;
+
+  @IsOptional()
+  @IsString()
+  seo_description?: string;
+}

--- a/src/apps/api/src/pages/dto/page-query.dto.ts
+++ b/src/apps/api/src/pages/dto/page-query.dto.ts
@@ -1,0 +1,9 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PageStatus } from '@prisma/client';
+
+export class PageQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsEnum(PageStatus)
+  status?: PageStatus;
+}

--- a/src/apps/api/src/pages/dto/update-page.dto.ts
+++ b/src/apps/api/src/pages/dto/update-page.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePageDto } from './create-page.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PageStatus } from '@prisma/client';
+
+export class UpdatePageDto extends PartialType(CreatePageDto) {
+  @IsOptional()
+  @IsEnum(PageStatus)
+  status?: PageStatus;
+}

--- a/src/apps/api/src/pages/pages.controller.ts
+++ b/src/apps/api/src/pages/pages.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { PagesService } from './pages.service';
+import { CreatePageDto } from './dto/create-page.dto';
+import { UpdatePageDto } from './dto/update-page.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { PageQueryDto } from './dto/page-query.dto';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('pages')
+@Controller('pages')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class PagesController {
+  constructor(private readonly pagesService: PagesService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: PageQueryDto) {
+    return this.pagesService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.pagesService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() createPageDto: CreatePageDto, @CurrentUser() user: any) {
+    return this.pagesService.create(createPageDto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() updatePageDto: UpdatePageDto) {
+    return this.pagesService.update(id, updatePageDto);
+  }
+
+  @Post(':id/publish')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  publish(@Param('id') id: string) {
+    return this.pagesService.publish(id);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.pagesService.delete(id);
+  }
+}

--- a/src/apps/api/src/pages/pages.module.ts
+++ b/src/apps/api/src/pages/pages.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PagesService } from './pages.service';
+import { PagesController } from './pages.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [PagesService],
+  controllers: [PagesController],
+})
+export class PagesModule {}

--- a/src/apps/api/src/pages/pages.service.ts
+++ b/src/apps/api/src/pages/pages.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma, Page, PageStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePageDto } from './dto/create-page.dto';
+import { UpdatePageDto } from './dto/update-page.dto';
+
+@Injectable()
+export class PagesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    status?: PageStatus;
+  }): Promise<{ data: Page[]; total: number }> {
+    const { skip = 0, take = 25, search, status } = params;
+
+    const where: Prisma.PageWhereInput = {
+      ...(status ? { status } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { slug: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.page.count({ where }),
+      this.prisma.page.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const page = await this.prisma.page.findUnique({ where: { id } });
+    if (!page) {
+      throw new NotFoundException('Página não encontrada');
+    }
+    return page;
+  }
+
+  async create(createPageDto: CreatePageDto, authorId: string) {
+    return this.prisma.page.create({
+      data: {
+        ...createPageDto,
+        author: { connect: { id: authorId } },
+      },
+    });
+  }
+
+  async update(id: string, updatePageDto: UpdatePageDto) {
+    await this.ensureExists(id);
+    return this.prisma.page.update({
+      where: { id },
+      data: updatePageDto,
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    return this.prisma.page.delete({ where: { id } });
+  }
+
+  async publish(id: string) {
+    await this.ensureExists(id);
+    return this.prisma.page.update({
+      where: { id },
+      data: { status: PageStatus.PUBLISHED },
+    });
+  }
+
+  private async ensureExists(id: string) {
+    const page = await this.prisma.page.findUnique({ where: { id } });
+    if (!page) {
+      throw new NotFoundException('Página não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/permissions/dto/create-permission.dto.ts
+++ b/src/apps/api/src/permissions/dto/create-permission.dto.ts
@@ -1,0 +1,14 @@
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class CreatePermissionDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsArray()
+  scopes?: string[];
+}

--- a/src/apps/api/src/permissions/dto/update-permission.dto.ts
+++ b/src/apps/api/src/permissions/dto/update-permission.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePermissionDto } from './create-permission.dto';
+
+export class UpdatePermissionDto extends PartialType(CreatePermissionDto) {}

--- a/src/apps/api/src/permissions/permissions.controller.ts
+++ b/src/apps/api/src/permissions/permissions.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { PermissionsService } from './permissions.service';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+import { UpdatePermissionDto } from './dto/update-permission.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('permissions')
+@Controller('permissions')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class PermissionsController {
+  constructor(private readonly permissionsService: PermissionsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN)
+  findAll(@Query() query: PaginationQueryDto) {
+    return this.permissionsService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN)
+  findOne(@Param('id') id: string) {
+    return this.permissionsService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  create(@Body() dto: CreatePermissionDto) {
+    return this.permissionsService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN)
+  update(@Param('id') id: string, @Body() dto: UpdatePermissionDto) {
+    return this.permissionsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.permissionsService.delete(id);
+  }
+
+  @Post(':id/assign/:userId')
+  @Roles(UserRole.ADMIN)
+  assign(@Param('id') id: string, @Param('userId') userId: string) {
+    return this.permissionsService.assignToUser(id, userId);
+  }
+
+  @Post(':id/revoke/:userId')
+  @Roles(UserRole.ADMIN)
+  revoke(@Param('id') id: string, @Param('userId') userId: string) {
+    return this.permissionsService.revokeFromUser(id, userId);
+  }
+}

--- a/src/apps/api/src/permissions/permissions.module.ts
+++ b/src/apps/api/src/permissions/permissions.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PermissionsService } from './permissions.service';
+import { PermissionsController } from './permissions.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PermissionsController],
+  providers: [PermissionsService],
+})
+export class PermissionsModule {}

--- a/src/apps/api/src/permissions/permissions.service.ts
+++ b/src/apps/api/src/permissions/permissions.service.ts
@@ -1,0 +1,103 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePermissionDto } from './dto/create-permission.dto';
+import { UpdatePermissionDto } from './dto/update-permission.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+
+@Injectable()
+export class PermissionsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: PaginationQueryDto) {
+    const { skip = 0, take = 25, search } = params;
+
+    const where = search
+      ? {
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { description: { contains: search, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.permission.count({ where }),
+      this.prisma.permission.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const permission = await this.prisma.permission.findUnique({
+      where: { id },
+      include: {
+        users: {
+          include: {
+            user: {
+              select: { id: true, name: true, email: true },
+            },
+          },
+        },
+      },
+    });
+
+    if (!permission) {
+      throw new NotFoundException('Permissão não encontrada');
+    }
+
+    return permission;
+  }
+
+  async create(dto: CreatePermissionDto) {
+    return this.prisma.permission.create({ data: dto });
+  }
+
+  async update(id: string, dto: UpdatePermissionDto) {
+    await this.ensureExists(id);
+    return this.prisma.permission.update({ where: { id }, data: dto });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.permission.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  async assignToUser(permissionId: string, userId: string) {
+    await this.ensureExists(permissionId);
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        permissions: {
+          upsert: {
+            where: { user_id_permission_id: { user_id: userId, permission_id: permissionId } },
+            update: {},
+            create: { permission: { connect: { id: permissionId } } },
+          },
+        },
+      },
+    });
+    return this.findById(permissionId);
+  }
+
+  async revokeFromUser(permissionId: string, userId: string) {
+    await this.ensureExists(permissionId);
+    await this.prisma.userPermission.delete({
+      where: { user_id_permission_id: { user_id: userId, permission_id: permissionId } },
+    });
+    return { revoked: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.permission.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Permissão não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/posts/dto/create-post.dto.ts
+++ b/src/apps/api/src/posts/dto/create-post.dto.ts
@@ -1,0 +1,54 @@
+import {
+  IsArray,
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+} from 'class-validator';
+import { PostStatus } from '@prisma/client';
+
+export class CreatePostDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  slug: string;
+
+  @IsString()
+  content: string;
+
+  @IsOptional()
+  @IsString()
+  excerpt?: string;
+
+  @IsOptional()
+  @IsUrl()
+  featured_image?: string;
+
+  @IsOptional()
+  @IsEnum(PostStatus)
+  status?: PostStatus;
+
+  @IsOptional()
+  @IsDateString()
+  publish_at?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  seo_title?: string;
+
+  @IsOptional()
+  @IsString()
+  seo_description?: string;
+
+  @IsOptional()
+  @IsArray()
+  categoryIds?: string[];
+
+  @IsOptional()
+  @IsArray()
+  tagIds?: string[];
+}

--- a/src/apps/api/src/posts/dto/post-query.dto.ts
+++ b/src/apps/api/src/posts/dto/post-query.dto.ts
@@ -1,0 +1,9 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { PostStatus } from '@prisma/client';
+
+export class PostQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsEnum(PostStatus)
+  status?: PostStatus;
+}

--- a/src/apps/api/src/posts/dto/update-post.dto.ts
+++ b/src/apps/api/src/posts/dto/update-post.dto.ts
@@ -1,0 +1,13 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePostDto } from './create-post.dto';
+import { IsArray, IsOptional } from 'class-validator';
+
+export class UpdatePostDto extends PartialType(CreatePostDto) {
+  @IsOptional()
+  @IsArray()
+  categoryIds?: string[];
+
+  @IsOptional()
+  @IsArray()
+  tagIds?: string[];
+}

--- a/src/apps/api/src/posts/posts.controller.ts
+++ b/src/apps/api/src/posts/posts.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { PostsService } from './posts.service';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { PostQueryDto } from './dto/post-query.dto';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('posts')
+@Controller('posts')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class PostsController {
+  constructor(private readonly postsService: PostsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: PostQueryDto) {
+    return this.postsService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.postsService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreatePostDto, @CurrentUser() user: any) {
+    return this.postsService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdatePostDto) {
+    return this.postsService.update(id, dto);
+  }
+
+  @Post(':id/publish')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  publish(@Param('id') id: string) {
+    return this.postsService.publish(id);
+  }
+
+  @Post(':id/views')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  incrementViews(@Param('id') id: string) {
+    return this.postsService.incrementViews(id);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.postsService.delete(id);
+  }
+}

--- a/src/apps/api/src/posts/posts.module.ts
+++ b/src/apps/api/src/posts/posts.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PostsService } from './posts.service';
+import { PostsController } from './posts.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [PostsController],
+  providers: [PostsService],
+})
+export class PostsModule {}

--- a/src/apps/api/src/posts/posts.service.ts
+++ b/src/apps/api/src/posts/posts.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+import { Prisma, PostStatus } from '@prisma/client';
+
+const defaultInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+  categories: {
+    include: {
+      category: true,
+    },
+  },
+  tags: {
+    include: {
+      tag: true,
+    },
+  },
+};
+
+type PostWithRelations = Prisma.PostGetPayload<{ include: typeof defaultInclude }>;
+
+@Injectable()
+export class PostsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    status?: PostStatus;
+  }): Promise<{ data: PostWithRelations[]; total: number }> {
+    const { skip = 0, take = 25, search, status } = params;
+
+    const where: Prisma.PostWhereInput = {
+      ...(status ? { status } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { slug: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.post.count({ where }),
+      this.prisma.post.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: defaultInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<PostWithRelations> {
+    const post = await this.prisma.post.findUnique({
+      where: { id },
+      include: defaultInclude,
+    });
+
+    if (!post) {
+      throw new NotFoundException('Notícia não encontrada');
+    }
+
+    return post;
+  }
+
+  async create(createPostDto: CreatePostDto, authorId: string): Promise<PostWithRelations> {
+    const { categoryIds = [], tagIds = [], ...rest } = createPostDto;
+
+    return this.prisma.post.create({
+      data: {
+        ...rest,
+        author: { connect: { id: authorId } },
+        categories: {
+          create: categoryIds.map((categoryId) => ({
+            category: { connect: { id: categoryId } },
+          })),
+        },
+        tags: {
+          create: tagIds.map((tagId) => ({
+            tag: { connect: { id: tagId } },
+          })),
+        },
+      },
+      include: defaultInclude,
+    });
+  }
+
+  async update(id: string, updatePostDto: UpdatePostDto): Promise<PostWithRelations> {
+    const { categoryIds, tagIds, ...rest } = updatePostDto;
+    await this.ensureExists(id);
+
+    const operations: Prisma.PrismaPromise<any>[] = [];
+
+    if (categoryIds) {
+      operations.push(
+        this.prisma.postCategory.deleteMany({ where: { post_id: id } }),
+      );
+      if (categoryIds.length > 0) {
+        operations.push(
+          this.prisma.postCategory.createMany({
+            data: categoryIds.map((categoryId) => ({
+              post_id: id,
+              category_id: categoryId,
+            })),
+          }),
+        );
+      }
+    }
+
+    if (tagIds) {
+      operations.push(this.prisma.postTag.deleteMany({ where: { post_id: id } }));
+      if (tagIds.length > 0) {
+        operations.push(
+          this.prisma.postTag.createMany({
+            data: tagIds.map((tagId) => ({
+              post_id: id,
+              tag_id: tagId,
+            })),
+          }),
+        );
+      }
+    }
+
+    await this.prisma.$transaction([
+      this.prisma.post.update({
+        where: { id },
+        data: rest,
+      }),
+      ...operations,
+    ]);
+
+    return this.findById(id);
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.post.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  async publish(id: string): Promise<PostWithRelations> {
+    await this.ensureExists(id);
+    return this.prisma.post.update({
+      where: { id },
+      data: { status: PostStatus.PUBLISHED, publish_at: new Date() },
+      include: defaultInclude,
+    });
+  }
+
+  async incrementViews(id: string) {
+    await this.ensureExists(id);
+    return this.prisma.post.update({
+      where: { id },
+      data: { views: { increment: 1 } },
+      select: { id: true, views: true },
+    });
+  }
+
+  private async ensureExists(id: string) {
+    const post = await this.prisma.post.findUnique({ where: { id } });
+    if (!post) {
+      throw new NotFoundException('Notícia não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/secretarias/dto/create-secretaria.dto.ts
+++ b/src/apps/api/src/secretarias/dto/create-secretaria.dto.ts
@@ -1,0 +1,43 @@
+import { IsArray, IsBoolean, IsEmail, IsOptional, IsString, IsUrl } from 'class-validator';
+
+export class CreateSecretariaDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  secretary_name?: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsEmail()
+  email?: string;
+
+  @IsOptional()
+  @IsUrl()
+  website?: string;
+
+  @IsOptional()
+  @IsUrl()
+  image?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  services?: string[];
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/secretarias/dto/secretaria-query.dto.ts
+++ b/src/apps/api/src/secretarias/dto/secretaria-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsBooleanString, IsOptional } from 'class-validator';
+
+export class SecretariaQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsBooleanString()
+  active?: string;
+}

--- a/src/apps/api/src/secretarias/dto/update-secretaria.dto.ts
+++ b/src/apps/api/src/secretarias/dto/update-secretaria.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSecretariaDto } from './create-secretaria.dto';
+
+export class UpdateSecretariaDto extends PartialType(CreateSecretariaDto) {}

--- a/src/apps/api/src/secretarias/secretarias.controller.ts
+++ b/src/apps/api/src/secretarias/secretarias.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { SecretariasService } from './secretarias.service';
+import { CreateSecretariaDto } from './dto/create-secretaria.dto';
+import { UpdateSecretariaDto } from './dto/update-secretaria.dto';
+import { SecretariaQueryDto } from './dto/secretaria-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('secretarias')
+@Controller('secretarias')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class SecretariasController {
+  constructor(private readonly secretariasService: SecretariasService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: SecretariaQueryDto) {
+    const { active, ...rest } = query;
+    return this.secretariasService.findAll({
+      ...rest,
+      active: active !== undefined ? active === 'true' : undefined,
+    });
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.secretariasService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateSecretariaDto, @CurrentUser() user: any) {
+    return this.secretariasService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateSecretariaDto) {
+    return this.secretariasService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.secretariasService.delete(id);
+  }
+}

--- a/src/apps/api/src/secretarias/secretarias.module.ts
+++ b/src/apps/api/src/secretarias/secretarias.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SecretariasService } from './secretarias.service';
+import { SecretariasController } from './secretarias.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SecretariasController],
+  providers: [SecretariasService],
+})
+export class SecretariasModule {}

--- a/src/apps/api/src/secretarias/secretarias.service.ts
+++ b/src/apps/api/src/secretarias/secretarias.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSecretariaDto } from './dto/create-secretaria.dto';
+import { UpdateSecretariaDto } from './dto/update-secretaria.dto';
+import { Prisma } from '@prisma/client';
+
+const secretariaInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+};
+
+type SecretariaWithAuthor = Prisma.SecretariaGetPayload<{ include: typeof secretariaInclude }>;
+
+@Injectable()
+export class SecretariasService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    active?: boolean;
+  }): Promise<{ data: SecretariaWithAuthor[]; total: number }> {
+    const { skip = 0, take = 25, search, active } = params;
+
+    const where: Prisma.SecretariaWhereInput = {
+      ...(active !== undefined ? { active } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.secretaria.count({ where }),
+      this.prisma.secretaria.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: secretariaInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<SecretariaWithAuthor> {
+    const secretaria = await this.prisma.secretaria.findUnique({
+      where: { id },
+      include: secretariaInclude,
+    });
+
+    if (!secretaria) {
+      throw new NotFoundException('Secretaria não encontrada');
+    }
+
+    return secretaria;
+  }
+
+  async create(dto: CreateSecretariaDto, authorId: string): Promise<SecretariaWithAuthor> {
+    return this.prisma.secretaria.create({
+      data: {
+        ...dto,
+        author: { connect: { id: authorId } },
+      },
+      include: secretariaInclude,
+    });
+  }
+
+  async update(id: string, dto: UpdateSecretariaDto): Promise<SecretariaWithAuthor> {
+    await this.ensureExists(id);
+    return this.prisma.secretaria.update({
+      where: { id },
+      data: dto,
+      include: secretariaInclude,
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.secretaria.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.secretaria.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Secretaria não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/services/dto/create-service.dto.ts
+++ b/src/apps/api/src/services/dto/create-service.dto.ts
@@ -1,0 +1,46 @@
+import { IsArray, IsBoolean, IsOptional, IsString } from 'class-validator';
+
+export class CreateServiceDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsString()
+  category: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  requirements?: string[];
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  documents?: string[];
+
+  @IsOptional()
+  @IsString()
+  process_time?: string;
+
+  @IsOptional()
+  @IsString()
+  cost?: string;
+
+  @IsOptional()
+  @IsString()
+  responsible_department?: string;
+
+  @IsOptional()
+  @IsString()
+  contact_info?: string;
+
+  @IsOptional()
+  @IsString()
+  online_url?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/services/dto/service-query.dto.ts
+++ b/src/apps/api/src/services/dto/service-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsOptional, IsString } from 'class-validator';
+
+export class ServiceQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsString()
+  category?: string;
+}

--- a/src/apps/api/src/services/dto/update-service.dto.ts
+++ b/src/apps/api/src/services/dto/update-service.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateServiceDto } from './create-service.dto';
+
+export class UpdateServiceDto extends PartialType(CreateServiceDto) {}

--- a/src/apps/api/src/services/services.controller.ts
+++ b/src/apps/api/src/services/services.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ServicesService } from './services.service';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
+import { ServiceQueryDto } from './dto/service-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('services')
+@Controller('services')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ServicesController {
+  constructor(private readonly servicesService: ServicesService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: ServiceQueryDto) {
+    return this.servicesService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.servicesService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateServiceDto, @CurrentUser() user: any) {
+    return this.servicesService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateServiceDto) {
+    return this.servicesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.servicesService.delete(id);
+  }
+}

--- a/src/apps/api/src/services/services.module.ts
+++ b/src/apps/api/src/services/services.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ServicesService } from './services.service';
+import { ServicesController } from './services.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ServicesController],
+  providers: [ServicesService],
+})
+export class ServicesModule {}

--- a/src/apps/api/src/services/services.service.ts
+++ b/src/apps/api/src/services/services.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateServiceDto } from './dto/create-service.dto';
+import { UpdateServiceDto } from './dto/update-service.dto';
+import { Prisma } from '@prisma/client';
+
+const serviceInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+};
+
+type ServiceWithAuthor = Prisma.ServiceGetPayload<{ include: typeof serviceInclude }>;
+
+@Injectable()
+export class ServicesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    category?: string;
+  }): Promise<{ data: ServiceWithAuthor[]; total: number }> {
+    const { skip = 0, take = 25, search, category } = params;
+
+    const where: Prisma.ServiceWhereInput = {
+      ...(category ? { category } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.service.count({ where }),
+      this.prisma.service.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: serviceInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<ServiceWithAuthor> {
+    const service = await this.prisma.service.findUnique({
+      where: { id },
+      include: serviceInclude,
+    });
+
+    if (!service) {
+      throw new NotFoundException('Serviço não encontrado');
+    }
+
+    return service;
+  }
+
+  async create(dto: CreateServiceDto, authorId: string): Promise<ServiceWithAuthor> {
+    return this.prisma.service.create({
+      data: {
+        ...dto,
+        author: { connect: { id: authorId } },
+      },
+      include: serviceInclude,
+    });
+  }
+
+  async update(id: string, dto: UpdateServiceDto): Promise<ServiceWithAuthor> {
+    await this.ensureExists(id);
+    return this.prisma.service.update({
+      where: { id },
+      data: dto,
+      include: serviceInclude,
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.service.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.service.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Serviço não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/settings/dto/upsert-setting.dto.ts
+++ b/src/apps/api/src/settings/dto/upsert-setting.dto.ts
@@ -1,0 +1,6 @@
+import { IsNotEmpty } from 'class-validator';
+
+export class UpsertSettingDto {
+  @IsNotEmpty()
+  value: any;
+}

--- a/src/apps/api/src/settings/settings.controller.ts
+++ b/src/apps/api/src/settings/settings.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import { SettingsService } from './settings.service';
+import { UpsertSettingDto } from './dto/upsert-setting.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('settings')
+@Controller('settings')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class SettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  findAll() {
+    return this.settingsService.findAll();
+  }
+
+  @Get(':key')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  findOne(@Param('key') key: string) {
+    return this.settingsService.findOne(key);
+  }
+
+  @Put(':key')
+  @Roles(UserRole.ADMIN)
+  upsert(@Param('key') key: string, @Body() dto: UpsertSettingDto) {
+    return this.settingsService.upsert(key, dto);
+  }
+
+  @Delete(':key')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('key') key: string) {
+    return this.settingsService.remove(key);
+  }
+}

--- a/src/apps/api/src/settings/settings.module.ts
+++ b/src/apps/api/src/settings/settings.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SettingsService } from './settings.service';
+import { SettingsController } from './settings.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SettingsController],
+  providers: [SettingsService],
+})
+export class SettingsModule {}

--- a/src/apps/api/src/settings/settings.service.ts
+++ b/src/apps/api/src/settings/settings.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { UpsertSettingDto } from './dto/upsert-setting.dto';
+
+@Injectable()
+export class SettingsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    const settings = await this.prisma.setting.findMany({
+      orderBy: { key: 'asc' },
+    });
+    return settings.reduce(
+      (acc, setting) => ({
+        ...acc,
+        [setting.key]: setting.value,
+      }),
+      {},
+    );
+  }
+
+  async findOne(key: string) {
+    const setting = await this.prisma.setting.findUnique({ where: { key } });
+    if (!setting) {
+      throw new NotFoundException('Configuração não encontrada');
+    }
+    return setting.value;
+  }
+
+  async upsert(key: string, dto: UpsertSettingDto) {
+    await this.prisma.setting.upsert({
+      where: { key },
+      create: { key, value: dto.value },
+      update: { value: dto.value },
+    });
+    return this.findOne(key);
+  }
+
+  async remove(key: string) {
+    await this.prisma.setting.delete({ where: { key } });
+    return { deleted: true };
+  }
+}

--- a/src/apps/api/src/slides/dto/create-slide.dto.ts
+++ b/src/apps/api/src/slides/dto/create-slide.dto.ts
@@ -1,0 +1,35 @@
+import { IsBoolean, IsNumber, IsOptional, IsString, IsUrl } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateSlideDto {
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  subtitle?: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsUrl()
+  image: string;
+
+  @IsOptional()
+  @IsUrl()
+  link?: string;
+
+  @IsOptional()
+  @IsString()
+  button_text?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  order?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/slides/dto/slides-query.dto.ts
+++ b/src/apps/api/src/slides/dto/slides-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsBooleanString, IsOptional } from 'class-validator';
+
+export class SlidesQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsBooleanString()
+  active?: string;
+}

--- a/src/apps/api/src/slides/dto/update-slide.dto.ts
+++ b/src/apps/api/src/slides/dto/update-slide.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSlideDto } from './create-slide.dto';
+
+export class UpdateSlideDto extends PartialType(CreateSlideDto) {}

--- a/src/apps/api/src/slides/slides.controller.ts
+++ b/src/apps/api/src/slides/slides.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { SlidesService } from './slides.service';
+import { CreateSlideDto } from './dto/create-slide.dto';
+import { UpdateSlideDto } from './dto/update-slide.dto';
+import { SlidesQueryDto } from './dto/slides-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('slides')
+@Controller('slides')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class SlidesController {
+  constructor(private readonly slidesService: SlidesService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: SlidesQueryDto) {
+    const { active, ...rest } = query;
+    return this.slidesService.findAll({
+      ...rest,
+      active: active !== undefined ? active === 'true' : undefined,
+    });
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.slidesService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateSlideDto) {
+    return this.slidesService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateSlideDto) {
+    return this.slidesService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.slidesService.delete(id);
+  }
+}

--- a/src/apps/api/src/slides/slides.module.ts
+++ b/src/apps/api/src/slides/slides.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SlidesService } from './slides.service';
+import { SlidesController } from './slides.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [SlidesController],
+  providers: [SlidesService],
+})
+export class SlidesModule {}

--- a/src/apps/api/src/slides/slides.service.ts
+++ b/src/apps/api/src/slides/slides.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateSlideDto } from './dto/create-slide.dto';
+import { UpdateSlideDto } from './dto/update-slide.dto';
+import { Prisma, Slide } from '@prisma/client';
+
+@Injectable()
+export class SlidesService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    active?: boolean;
+  }): Promise<{ data: Slide[]; total: number }> {
+    const { skip = 0, take = 25, search, active } = params;
+
+    const where: Prisma.SlideWhereInput = {
+      ...(active !== undefined ? { active } : {}),
+      ...(search
+        ? {
+            OR: [
+              { title: { contains: search, mode: 'insensitive' } },
+              { subtitle: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.slide.count({ where }),
+      this.prisma.slide.findMany({
+        where,
+        skip,
+        take,
+        orderBy: [{ order: 'asc' }, { created_at: 'desc' }],
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const slide = await this.prisma.slide.findUnique({ where: { id } });
+    if (!slide) {
+      throw new NotFoundException('Slide não encontrado');
+    }
+    return slide;
+  }
+
+  async create(dto: CreateSlideDto) {
+    return this.prisma.slide.create({ data: dto });
+  }
+
+  async update(id: string, dto: UpdateSlideDto) {
+    await this.ensureExists(id);
+    return this.prisma.slide.update({ where: { id }, data: dto });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.slide.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.slide.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Slide não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/tags/dto/create-tag.dto.ts
+++ b/src/apps/api/src/tags/dto/create-tag.dto.ts
@@ -1,0 +1,17 @@
+import { IsEnum, IsOptional, IsString } from 'class-validator';
+import { TagType } from '@prisma/client';
+
+export class CreateTagDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  slug: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsEnum(TagType)
+  type: TagType;
+}

--- a/src/apps/api/src/tags/dto/tag-query.dto.ts
+++ b/src/apps/api/src/tags/dto/tag-query.dto.ts
@@ -1,0 +1,9 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsEnum, IsOptional } from 'class-validator';
+import { TagType } from '@prisma/client';
+
+export class TagQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsEnum(TagType)
+  type?: TagType;
+}

--- a/src/apps/api/src/tags/dto/update-tag.dto.ts
+++ b/src/apps/api/src/tags/dto/update-tag.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTagDto } from './create-tag.dto';
+
+export class UpdateTagDto extends PartialType(CreateTagDto) {}

--- a/src/apps/api/src/tags/tags.controller.ts
+++ b/src/apps/api/src/tags/tags.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { TagQueryDto } from './dto/tag-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('tags')
+@Controller('tags')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class TagsController {
+  constructor(private readonly tagsService: TagsService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: TagQueryDto) {
+    return this.tagsService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.tagsService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateTagDto) {
+    return this.tagsService.create(dto);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateTagDto) {
+    return this.tagsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.tagsService.delete(id);
+  }
+}

--- a/src/apps/api/src/tags/tags.module.ts
+++ b/src/apps/api/src/tags/tags.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TagsService } from './tags.service';
+import { TagsController } from './tags.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [TagsService],
+  controllers: [TagsController],
+})
+export class TagsModule {}

--- a/src/apps/api/src/tags/tags.service.ts
+++ b/src/apps/api/src/tags/tags.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { Prisma, Tag, TagType } from '@prisma/client';
+
+@Injectable()
+export class TagsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    type?: TagType;
+  }): Promise<{ data: Tag[]; total: number }> {
+    const { skip = 0, take = 25, search, type } = params;
+
+    const where: Prisma.TagWhereInput = {
+      ...(type ? { type } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { slug: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.tag.count({ where }),
+      this.prisma.tag.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string) {
+    const tag = await this.prisma.tag.findUnique({ where: { id } });
+    if (!tag) {
+      throw new NotFoundException('Tag não encontrada');
+    }
+    return tag;
+  }
+
+  async create(dto: CreateTagDto) {
+    return this.prisma.tag.create({ data: dto });
+  }
+
+  async update(id: string, dto: UpdateTagDto) {
+    await this.ensureExists(id);
+    return this.prisma.tag.update({ where: { id }, data: dto });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.tag.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.tag.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Tag não encontrada');
+    }
+  }
+}

--- a/src/apps/api/src/tourism/dto/create-tourism-point.dto.ts
+++ b/src/apps/api/src/tourism/dto/create-tourism-point.dto.ts
@@ -1,0 +1,52 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsLatitude,
+  IsLongitude,
+  IsOptional,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateTourismPointDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  slug: string;
+
+  @IsString()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsLatitude()
+  latitude?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsLongitude()
+  longitude?: number;
+
+  @IsOptional()
+  @IsUrl()
+  image?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsUrl({}, { each: true })
+  gallery?: string[];
+
+  @IsOptional()
+  @IsString()
+  contact_info?: string;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/tourism/dto/tourism-query.dto.ts
+++ b/src/apps/api/src/tourism/dto/tourism-query.dto.ts
@@ -1,0 +1,8 @@
+import { PaginationQueryDto } from '../../common/dto/pagination-query.dto';
+import { IsBooleanString, IsOptional } from 'class-validator';
+
+export class TourismQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsBooleanString()
+  active?: string;
+}

--- a/src/apps/api/src/tourism/dto/update-tourism-point.dto.ts
+++ b/src/apps/api/src/tourism/dto/update-tourism-point.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTourismPointDto } from './create-tourism-point.dto';
+
+export class UpdateTourismPointDto extends PartialType(CreateTourismPointDto) {}

--- a/src/apps/api/src/tourism/tourism.controller.ts
+++ b/src/apps/api/src/tourism/tourism.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { TourismService } from './tourism.service';
+import { CreateTourismPointDto } from './dto/create-tourism-point.dto';
+import { UpdateTourismPointDto } from './dto/update-tourism-point.dto';
+import { TourismQueryDto } from './dto/tourism-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('tourism-points')
+@Controller('tourism-points')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class TourismController {
+  constructor(private readonly tourismService: TourismService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findAll(@Query() query: TourismQueryDto) {
+    const { active, ...rest } = query;
+    return this.tourismService.findAll({
+      ...rest,
+      active: active !== undefined ? active === 'true' : undefined,
+    });
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR, UserRole.VIEWER)
+  findOne(@Param('id') id: string) {
+    return this.tourismService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  create(@Body() dto: CreateTourismPointDto, @CurrentUser() user: any) {
+    return this.tourismService.create(dto, user.id);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN, UserRole.EDITOR)
+  update(@Param('id') id: string, @Body() dto: UpdateTourismPointDto) {
+    return this.tourismService.update(id, dto);
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  remove(@Param('id') id: string) {
+    return this.tourismService.delete(id);
+  }
+}

--- a/src/apps/api/src/tourism/tourism.module.ts
+++ b/src/apps/api/src/tourism/tourism.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TourismService } from './tourism.service';
+import { TourismController } from './tourism.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [TourismController],
+  providers: [TourismService],
+})
+export class TourismModule {}

--- a/src/apps/api/src/tourism/tourism.service.ts
+++ b/src/apps/api/src/tourism/tourism.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTourismPointDto } from './dto/create-tourism-point.dto';
+import { UpdateTourismPointDto } from './dto/update-tourism-point.dto';
+import { Prisma } from '@prisma/client';
+
+const tourismInclude = {
+  author: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+};
+
+type TourismPointWithAuthor = Prisma.TourismPointGetPayload<{ include: typeof tourismInclude }>;
+
+@Injectable()
+export class TourismService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+    active?: boolean;
+  }): Promise<{ data: TourismPointWithAuthor[]; total: number }> {
+    const { skip = 0, take = 25, search, active } = params;
+
+    const where: Prisma.TourismPointWhereInput = {
+      ...(active !== undefined ? { active } : {}),
+      ...(search
+        ? {
+            OR: [
+              { name: { contains: search, mode: 'insensitive' } },
+              { description: { contains: search, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    };
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.tourismPoint.count({ where }),
+      this.prisma.tourismPoint.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+        include: tourismInclude,
+      }),
+    ]);
+
+    return { total, data };
+  }
+
+  async findById(id: string): Promise<TourismPointWithAuthor> {
+    const point = await this.prisma.tourismPoint.findUnique({
+      where: { id },
+      include: tourismInclude,
+    });
+
+    if (!point) {
+      throw new NotFoundException('Ponto turístico não encontrado');
+    }
+
+    return point;
+  }
+
+  async create(dto: CreateTourismPointDto, authorId: string): Promise<TourismPointWithAuthor> {
+    return this.prisma.tourismPoint.create({
+      data: {
+        ...dto,
+        author: { connect: { id: authorId } },
+      },
+      include: tourismInclude,
+    });
+  }
+
+  async update(id: string, dto: UpdateTourismPointDto): Promise<TourismPointWithAuthor> {
+    await this.ensureExists(id);
+    return this.prisma.tourismPoint.update({
+      where: { id },
+      data: dto,
+      include: tourismInclude,
+    });
+  }
+
+  async delete(id: string) {
+    await this.ensureExists(id);
+    await this.prisma.tourismPoint.delete({ where: { id } });
+    return { deleted: true };
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.tourismPoint.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Ponto turístico não encontrado');
+    }
+  }
+}

--- a/src/apps/api/src/users/dto/create-user.dto.ts
+++ b/src/apps/api/src/users/dto/create-user.dto.ts
@@ -1,0 +1,23 @@
+import { IsBoolean, IsEmail, IsEnum, IsOptional, IsString, MinLength } from 'class-validator';
+import { UserRole } from '@prisma/client';
+
+export class CreateUserDto {
+  @IsEmail()
+  email: string;
+
+  @IsString()
+  @MinLength(3)
+  name: string;
+
+  @IsString()
+  @MinLength(8)
+  password: string;
+
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
+
+  @IsOptional()
+  @IsBoolean()
+  active?: boolean;
+}

--- a/src/apps/api/src/users/dto/update-user.dto.ts
+++ b/src/apps/api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,10 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateUserDto } from './create-user.dto';
+import { IsOptional, IsString, MinLength } from 'class-validator';
+
+export class UpdateUserDto extends PartialType(CreateUserDto) {
+  @IsOptional()
+  @IsString()
+  @MinLength(8)
+  password?: string;
+}

--- a/src/apps/api/src/users/users.controller.ts
+++ b/src/apps/api/src/users/users.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { PaginationQueryDto } from '../common/dto/pagination-query.dto';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('users')
+@Controller('users')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @Roles(UserRole.ADMIN)
+  findAll(@Query() query: PaginationQueryDto) {
+    return this.usersService.findAll(query);
+  }
+
+  @Get(':id')
+  @Roles(UserRole.ADMIN)
+  findOne(@Param('id') id: string) {
+    return this.usersService.findById(id);
+  }
+
+  @Post()
+  @Roles(UserRole.ADMIN)
+  create(@Body() createUserDto: CreateUserDto) {
+    return this.usersService.create(createUserDto);
+  }
+
+  @Patch(':id')
+  @Roles(UserRole.ADMIN)
+  update(@Param('id') id: string, @Body() updateUserDto: UpdateUserDto) {
+    return this.usersService.update(id, updateUserDto);
+  }
+
+  @Patch(':id/deactivate')
+  @Roles(UserRole.ADMIN)
+  deactivate(@Param('id') id: string) {
+    return this.usersService.deactivate(id);
+  }
+}

--- a/src/apps/api/src/users/users.module.ts
+++ b/src/apps/api/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [UsersService],
+  controllers: [UsersController],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/apps/api/src/users/users.service.ts
+++ b/src/apps/api/src/users/users.service.ts
@@ -1,0 +1,117 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma, User, UserRole } from '@prisma/client';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UpdateUserDto } from './dto/update-user.dto';
+import { hash } from 'bcryptjs';
+
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll(params: {
+    skip?: number;
+    take?: number;
+    search?: string;
+  }): Promise<{ data: Array<Omit<User, 'password'>>; total: number }> {
+    const { skip = 0, take = 25, search } = params;
+
+    const where: Prisma.UserWhereInput = search
+      ? {
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { email: { contains: search, mode: 'insensitive' } },
+          ],
+        }
+      : {};
+
+    const [total, data] = await this.prisma.$transaction([
+      this.prisma.user.count({ where }),
+      this.prisma.user.findMany({
+        where,
+        skip,
+        take,
+        orderBy: { created_at: 'desc' },
+      }),
+    ]);
+
+    return { total, data: data.map((user) => this.sanitize(user)) };
+  }
+
+  async findById(id: string): Promise<Omit<User, 'password'>> {
+    const user = await this.prisma.user.findUnique({ where: { id } });
+
+    if (!user) {
+      throw new NotFoundException('Usuário não encontrado');
+    }
+
+    return this.sanitize(user);
+  }
+
+  async findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+
+  async create(createUserDto: CreateUserDto): Promise<Omit<User, 'password'>> {
+    const password = await hash(createUserDto.password, 12);
+
+    const user = await this.prisma.user.create({
+      data: {
+        email: createUserDto.email,
+        name: createUserDto.name,
+        password,
+        role: createUserDto.role ?? UserRole.EDITOR,
+        active: createUserDto.active ?? true,
+      },
+    });
+
+    return this.sanitize(user);
+  }
+
+  async update(
+    id: string,
+    updateUserDto: UpdateUserDto,
+  ): Promise<Omit<User, 'password'>> {
+    await this.ensureExists(id);
+
+    const data: Prisma.UserUpdateInput = {
+      email: updateUserDto.email,
+      name: updateUserDto.name,
+      role: updateUserDto.role,
+      active: updateUserDto.active,
+    };
+
+    if (updateUserDto.password) {
+      data.password = await hash(updateUserDto.password, 12);
+    }
+
+    const user = await this.prisma.user.update({
+      where: { id },
+      data,
+    });
+
+    return this.sanitize(user);
+  }
+
+  async deactivate(id: string): Promise<Omit<User, 'password'>> {
+    await this.ensureExists(id);
+    const user = await this.prisma.user.update({
+      where: { id },
+      data: { active: false },
+    });
+
+    return this.sanitize(user);
+  }
+
+  private async ensureExists(id: string) {
+    const exists = await this.prisma.user.findUnique({ where: { id } });
+    if (!exists) {
+      throw new NotFoundException('Usuário não encontrado');
+    }
+  }
+
+  private sanitize(user: User): Omit<User, 'password'> {
+    const { password, ...rest } = user;
+    return rest;
+  }
+}


### PR DESCRIPTION
## Summary
- add NestJS controllers, services, and modules to cover the entire CMS surface (auth, users, content, organization, media, forms, permissions, and settings)
- expand the Prisma schema with posts, categories, tags, tourism points, permissions, and relationships to support the new endpoints
- integrate MinIO-backed media storage plus shared guards, decorators, and Swagger tagging for the administrative API

## Testing
- npm install *(fails: npm cannot resolve workspace:* dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b091d63883269e80738b14565f85